### PR TITLE
Fix deprecated warning by replacing "Discourse.Category" with importing Category class

### DIFF
--- a/assets/javascripts/discourse/lib/rating-utilities.js.es6
+++ b/assets/javascripts/discourse/lib/rating-utilities.js.es6
@@ -1,8 +1,9 @@
 import { ajax } from 'discourse/lib/ajax';
 import { popupAjaxError } from 'discourse/lib/ajax-error';
+import Category from 'discourse/models/category';
 
 let ratingEnabled = function(type, tags, categoryId) {
-  let category = Discourse.Category.findById(categoryId),
+  let category = Category.findById(categoryId),
       catEnabled = category && category.rating_enabled,
       tagEnabled = tags && tags.filter(function(t){
                       return Discourse.SiteSettings.rating_tags.split('|').indexOf(t) !== -1;


### PR DESCRIPTION
Fixes #15 

Original warning:

`Deprecation notice: Import the Category class instead of using Discourse.Category (deprecated since Discourse 2.4.0) (removal in Discourse 2.5.0)`