### PR TITLE
FIX: use .slug instead of slug_path as we are using slug while migrat…

### DIFF
--- a/db/migrate/20200520084648_add_rating_types.rb
+++ b/db/migrate/20200520084648_add_rating_types.rb
@@ -31,7 +31,7 @@ class AddRatingTypes < ActiveRecord::Migration[6.0]
         if category = Category.find(row.category_id)
           DiscourseRatings::Object.create(
             'category',
-            category.full_slug('/'),
+            category.slug,
             [DiscourseRatings::RatingType::NONE]
           )
         end

--- a/plugin.rb
+++ b/plugin.rb
@@ -70,7 +70,7 @@ after_initialize do
   ###### Category && Tag ######
   
   add_to_class(:category, :rating_types) do
-    DiscourseRatings::Object.get('category', full_slug("/"))
+    DiscourseRatings::Object.get('category', self.slug)
   end
   
   add_to_class(:tag, :rating_types) do


### PR DESCRIPTION
…ing ratings

- We use slugs while creating/migrating rating settings. The categories are stored as `category_catname`. And `full_slug('/')` give us `category_catname/catid` which causes unexpected behavior.

Suggestion: Wouldn't it be better to use category id instead of the slug so our settings still work if categories are renamed.