### PR TITLE
Check if count is int

### DIFF
--- a/lib/ratings/rating.rb
+++ b/lib/ratings/rating.rb
@@ -13,7 +13,7 @@ class DiscourseRatings::Rating
     @type = attrs[:type].to_s
     @value = attrs[:value].to_f
     @weight = is_int?(attrs[:weight]) ? attrs[:weight].to_i : 1
-    @count = attrs[:count].to_i if attrs[:count] != nil
+    @count = is_int?(attrs[:count]) ? attrs[:count].to_i : 0
   end
   
   def is_int?(str)


### PR DESCRIPTION
@fzngagan I encountered the issue where a custom field can be saved as an array in the db when working on a client's db where the ratings plugin had been used. This ensures an exception does not occur if that custom field bug arises.