### PR TITLE
Bugfix: reply links were not always working

### DIFF
--- a/assets/javascripts/discourse/initializers/initialize-ratings.js.es6
+++ b/assets/javascripts/discourse/initializers/initialize-ratings.js.es6
@@ -31,7 +31,7 @@ export default {
       api.decorateWidget("poster-name:after", function (helper) {
         const post = helper.getModel();
 
-        if (post && post.topic.show_ratings && post.ratings) {
+        if (post && post.topic && post.topic.show_ratings && post.ratings) {
           return helper.rawHtml(
             `${new Handlebars.SafeString(ratingListHtml(post.ratings))}`
           );


### PR DESCRIPTION
For some reason the "parent post" links on replies were triggering a Javascript error in this plugin `t.topic is undefined` in this line 

`if (post && post.topic.show_ratings && post.ratings) {`

in `assets/javascripts/discourse/initializers/initialize-ratings.js.es6`

I am not sure why this was happening, scrolling up and down in the topic prevented the error from happening 🤔 
For now I just added a check that prevents the Javascript error.