### PR TITLE
Google no longer accepts the generic CreativeWork itemtype. :-(

### DIFF
--- a/app/views/connectors/topic_header/aggregate_rating.html.erb
+++ b/app/views/connectors/topic_header/aggregate_rating.html.erb
@@ -1,5 +1,5 @@
 <% if @topic_view.topic.ratings.present? %>
-  <div itemscope itemtype="http://schema.org/CreativeWork">
+  <div itemscope itemtype="http://schema.org/CreativeWorkSeries">
     <span itemprop="name"><%= @topic_view.topic.title %></span>
     <% if @topic_view.topic.image_url.present? %>
       <span itemprop="image"><%= @topic_view.topic.image_url %></span>


### PR DESCRIPTION
At some point Google stopped counting CreativeWork as a valid itemtype, so topics with ratings throw errors in Google Console:

![Screenshot 2023-05-20 at 12 59 10 PM](https://github.com/paviliondev/discourse-ratings/assets/1520759/bc827e13-18dd-46ad-a270-1bd45f4c9c12)

The list of itemtypes that Google considers valid is on [this page](https://developers.google.com/search/docs/appearance/structured-data/review-snippet#aggregated-rating-type-definition). All of them are too specific, so I picked one that seemed closest to the spirit of a generic review and also worked for the specific review I was testing: [CreativeWorkSeries](https://schema.org/CreativeWorkSeries).

This is a temporary patch, however. A more permanent solution would be to let users select the itemtype. Maybe make it a per-category or per-tag setting? Or just give users a dropdown? Neither is a particularly good solution, however. Just changing to a valid itemtype is good enough for my purposes at the moment.