### PR TITLE
FIX: Loading spinner stuck on Categories add, update and destroy

### DIFF
--- a/assets/javascripts/discourse/components/rating-object-list.js.es6
+++ b/assets/javascripts/discourse/components/rating-object-list.js.es6
@@ -44,8 +44,9 @@ export default Component.extend({
         if (result.success) {
           this.refresh();
         } else {
-          this.set("loading", false);
+          obj.set("hasError", true);
         }
+        this.set("loading", false);
       });
     },
 
@@ -59,8 +60,9 @@ export default Component.extend({
         if (result.success) {
           this.refresh();
         } else {
-          this.set("loading", false);
+          obj.set("hasError", true);
         }
+        this.set("loading", false);
       });
     },
 
@@ -77,8 +79,9 @@ export default Component.extend({
           if (result.success) {
             this.refresh();
           } else {
-            this.set("loading", false);
+            obj.set("hasError", true);
           }
+          this.set("loading", false);
         });
       }
     },


### PR DESCRIPTION
**Problem**
Loading spinner never disappears when adding updating or destroying `rating-object`s 
![imagen](https://github.com/paviliondev/discourse-ratings/assets/50383815/73de6e8f-2096-4e60-a191-44dd3d49f69d)

**Solution**  

Set the loading spinner to false after the promise resolution
