### PR TITLE
Fix: crash when post was in review queue

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -144,7 +144,7 @@ after_initialize do
   ::PostRevisor.prepend PostRevisorRatingsExtension
 
   add_to_class(:post, :ratings) do
-    DiscourseRatings::Rating.build_model_list(custom_fields, topic.rating_types)
+    DiscourseRatings::Rating.build_model_list(custom_fields, topic.rating_types) if topic
   end
 
   add_to_class(:post, :rated_types) do


### PR DESCRIPTION
Under some circumstances there is no post.topic and the plugin crashes